### PR TITLE
Feature/return case result

### DIFF
--- a/test/main.go
+++ b/test/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/tvative/goapitest"
@@ -52,10 +53,12 @@ func main() {
 
 	// Add test cases
 	for _, tc := range testCases {
-		err := instance.Add(tc)
+		result, err := instance.Add(tc)
 		if err != nil {
 			panic(err)
 		}
+
+		fmt.Printf("%s\n", result.ResultGot)
 	}
 
 	// Dump test cases


### PR DESCRIPTION
In this PR, an error result return feature has been added. Developers can now obtain all result information in a test case when using the `Add()` function.

```go
// Example

result, err := instance.Add(tc)
if err != nil {
  panic(err)
}

fmt.Printf("%s\n", result.ResultGot)
```